### PR TITLE
Prevent 'taskhash mismatch' errors during UBI creation.

### DIFF
--- a/conf/machine/include/xpeedc.inc
+++ b/conf/machine/include/xpeedc.inc
@@ -41,11 +41,14 @@ UBINIZE_ARGS = "-m 2048 -p 128KiB"
 IMAGEDIR ?= "${MACHINE}"
 IMGDEPLOYDIR ?= "${DEPLOY_DIR_IMAGE}"
 
+IMAGEVERSION := "${DISTRO_NAME}-${DISTRO_VERSION}-${DATE}"
+IMAGEVERSION[vardepsexclude] = "DATE"
+
 IMAGE_CMD_ubi_append = " \
 	mkdir -p ${IMGDEPLOYDIR}/${IMAGEDIR}; \
 	cp -f ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ubi ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.bin; \
 	gzip -9c ${DEPLOY_DIR_IMAGE}/vmlinux-${MACHINE}.bin > ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
-	echo ${DISTRO_NAME}-${DISTRO_VERSION}-${DATE} > ${IMGDEPLOYDIR}/${IMAGEDIR}/imageversion; \
+	echo "${IMAGEVERSION}" > ${IMGDEPLOYDIR}/${IMAGEDIR}/imageversion; \
 	echo "rename this file to 'force' to force an update without confirmation" > ${IMGDEPLOYDIR}/${IMAGEDIR}/noforce; \
 	cd ${IMGDEPLOYDIR}; \
 	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_usb.zip ${IMAGEDIR}/*; \


### PR DESCRIPTION
The recipe writes the current DATE to a file.
This may evaluate to a different value in a subprocess, e.g. due to locale settings.
To work around that, put the date stamp into a variable at parse time and exclude it from dependency parsing.

This should solve the occasional 'taskhash mismatch' errors that occur while building.

Signed-off-by: Erik Slagter <erik@openpli.org>